### PR TITLE
feat(list.component): mattabを使うようマークアップ変更

### DIFF
--- a/src/app/list/list.module.ts
+++ b/src/app/list/list.module.ts
@@ -3,13 +3,14 @@ import { CommonModule } from '@angular/common';
 
 import { ListRoutingModule } from './list-routing.module';
 import { ListComponent } from './list/list.component';
-import {MatButtonToggleModule} from '@angular/material/button-toggle';
+import { MatButtonToggleModule } from '@angular/material/button-toggle';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
-import {TextFieldModule} from '@angular/cdk/text-field';
-import {MatFormFieldModule} from '@angular/material/form-field';
+import { TextFieldModule } from '@angular/cdk/text-field';
+import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
-import {MatSelectModule} from '@angular/material/select';
+import { MatSelectModule } from '@angular/material/select';
 import { MatButtonModule } from '@angular/material/button';
+import { MatTabsModule } from '@angular/material/tabs';
 
 @NgModule({
   declarations: [ListComponent],
@@ -23,7 +24,8 @@ import { MatButtonModule } from '@angular/material/button';
     MatFormFieldModule,
     MatInputModule,
     MatSelectModule,
-    MatButtonModule
-  ]
+    MatButtonModule,
+    MatTabsModule,
+  ],
 })
-export class ListModule { }
+export class ListModule {}

--- a/src/app/list/list/list.component.html
+++ b/src/app/list/list/list.component.html
@@ -1,21 +1,4 @@
 <div class="container">
-  <h1 class="title">作成した問題</h1>
-
-  <mat-button-toggle-group
-    class="types"
-    name="fontStyle"
-    aria-label="Font Style"
-  >
-    <mat-button-toggle class="type" value="random">ランダム</mat-button-toggle>
-    <mat-button-toggle class="type" value="noun">名詞</mat-button-toggle>
-    <mat-button-toggle class="type" value="verb">動詞</mat-button-toggle>
-    <mat-button-toggle class="type" value="adjective">形容詞</mat-button-toggle>
-    <mat-button-toggle class="type" value="adverb">副詞</mat-button-toggle>
-    <mat-button-toggle class="type" value="preposition"
-      >前置詞</mat-button-toggle
-    >
-  </mat-button-toggle-group>
-
   <form class="search-form" [formGroup]="form" (ngSubmit)="submit()">
     <mat-form-field class="search-form__keyward" appearance="outline">
       <input
@@ -47,86 +30,47 @@
     </div>
   </form>
 
-  <div class="grid">
-    <div class="card">
-      <p class="card__title">オバマ大統領のスピーチ</p>
-      <figure class="card__cover"></figure>
-      <p class="card__accuracy">正答率: <strong>60</strong>%</p>
-    </div>
-    <div class="card">
-      <p class="card__title">オバマ大統領のスピーチ</p>
-      <figure class="card__cover"></figure>
-      <p class="card__accuracy">正答率: <strong>60</strong>%</p>
-    </div>
-    <div class="card">
-      <p class="card__title">オバマ大統領のスピーチ</p>
-      <figure class="card__cover"></figure>
-      <p class="card__accuracy">正答率: <strong>60</strong>%</p>
-    </div>
-    <div class="card">
-      <p class="card__title">オバマ大統領のスピーチ</p>
-      <figure class="card__cover"></figure>
-      <p class="card__accuracy">正答率: <strong>60</strong>%</p>
-    </div>
-    <div class="card">
-      <p class="card__title">オバマ大統領のスピーチ</p>
-      <figure class="card__cover"></figure>
-      <p class="card__accuracy">正答率: <strong>60</strong>%</p>
-    </div>
-    <div class="card">
-      <p class="card__title">オバマ大統領のスピーチ</p>
-      <figure class="card__cover"></figure>
-      <p class="card__accuracy">正答率: <strong>60</strong>%</p>
-    </div>
-    <div class="card">
-      <p class="card__title">オバマ大統領のスピーチ</p>
-      <figure class="card__cover"></figure>
-      <p class="card__accuracy">正答率: <strong>60</strong>%</p>
-    </div>
-    <div class="card">
-      <p class="card__title">オバマ大統領のスピーチ</p>
-      <figure class="card__cover"></figure>
-      <p class="card__accuracy">正答率: <strong>60</strong>%</p>
-    </div>
-    <div class="card">
-      <p class="card__title">オバマ大統領のスピーチ</p>
-      <figure class="card__cover"></figure>
-      <p class="card__accuracy">正答率: <strong>60</strong>%</p>
-    </div>
-    <div class="card">
-      <p class="card__title">オバマ大統領のスピーチ</p>
-      <figure class="card__cover"></figure>
-      <p class="card__accuracy">正答率: <strong>60</strong>%</p>
-    </div>
-    <div class="card">
-      <p class="card__title">オバマ大統領のスピーチ</p>
-      <figure class="card__cover"></figure>
-      <p class="card__accuracy">正答率: <strong>60</strong>%</p>
-    </div>
-    <div class="card">
-      <p class="card__title">オバマ大統領のスピーチ</p>
-      <figure class="card__cover"></figure>
-      <p class="card__accuracy">正答率: <strong>60</strong>%</p>
-    </div>
-    <div class="card">
-      <p class="card__title">オバマ大統領のスピーチ</p>
-      <figure class="card__cover"></figure>
-      <p class="card__accuracy">正答率: <strong>60</strong>%</p>
-    </div>
-    <div class="card">
-      <p class="card__title">オバマ大統領のスピーチ</p>
-      <figure class="card__cover"></figure>
-      <p class="card__accuracy">正答率: <strong>60</strong>%</p>
-    </div>
-    <div class="card">
-      <p class="card__title">オバマ大統領のスピーチ</p>
-      <figure class="card__cover"></figure>
-      <p class="card__accuracy">正答率: <strong>60</strong>%</p>
-    </div>
-    <div class="card">
-      <p class="card__title">オバマ大統領のスピーチ</p>
-      <figure class="card__cover"></figure>
-      <p class="card__accuracy">正答率: <strong>60</strong>%</p>
-    </div>
-  </div>
+  <mat-tab-group
+    class="tab"
+    (selectedTabChange)="getProblemsbyType($event)"
+    animationDuration="0ms"
+  >
+    <mat-tab label="ランダム">
+      <div class="grid">
+        <div *ngFor="let problem of problems" class="card">
+          <p class="card_title">{{ problem.title }}</p>
+          <figure class="card__cover"></figure>
+          <p class="class__accuracy">
+            正答率: <strong>{{ problem.correctAnswerRate }}</strong
+            >%
+          </p>
+        </div>
+      </div>
+    </mat-tab>
+    <mat-tab label="名詞">
+      <div *ngFor="let problem of problems" class="problems">
+        {{ problem.title }}
+      </div>
+    </mat-tab>
+    <mat-tab label="動詞">
+      <div *ngFor="let problem of problems" class="problems">
+        {{ problem.title }}
+      </div>
+    </mat-tab>
+    <mat-tab label="形容詞">
+      <div *ngFor="let problem of problems" class="problems">
+        {{ problem.title }}
+      </div>
+    </mat-tab>
+    <mat-tab label="副詞">
+      <div *ngFor="let problem of problems" class="problems">
+        {{ problem.title }}
+      </div>
+    </mat-tab>
+    <mat-tab label="前置詞">
+      <div *ngFor="let problem of problems" class="problems">
+        {{ problem.title }}
+      </div>
+    </mat-tab>
+  </mat-tab-group>
 </div>

--- a/src/app/list/list/list.component.html
+++ b/src/app/list/list/list.component.html
@@ -38,7 +38,7 @@
     <mat-tab label="ランダム">
       <div class="grid">
         <div *ngFor="let problem of problems" class="card">
-          <p class="card_title">{{ problem.title }}</p>
+          <p class="card__title">{{ problem.title }}</p>
           <figure class="card__cover"></figure>
           <p class="class__accuracy">
             正答率: <strong>{{ problem.correctAnswerRate }}</strong

--- a/src/app/list/list/list.component.scss
+++ b/src/app/list/list/list.component.scss
@@ -1,7 +1,11 @@
 .container {
-  margin-right: auto;
-  margin-left: auto;
-  width: 960px;
+  width: 100%;
+  min-width: 960px;
+  margin: 0 auto;
+}
+
+.tab {
+  margin-top: 10px;
 }
 
 .title {
@@ -13,7 +17,7 @@
 }
 
 .search-form {
-  padding-top: 40px;
+  padding-top: 60px;
   display: flex;
   &__keyward {
     width: 50%;
@@ -33,7 +37,7 @@
 
 .grid {
   display: grid;
-  grid-template-columns: repeat(4, 1fr);
+  grid-template-columns: repeat(5, 1fr);
   padding: 16px;
   gap: 16px;
 }
@@ -41,6 +45,7 @@
 .card {
   border-radius: 4px;
   text-align: center;
+  box-shadow: 0 0 3px #ccc;
   &__cover {
     padding-bottom: 52.5%;
     width: 100%;


### PR DESCRIPTION
fix #42 


元々mat-button-toggleを使って同一ページ内のtabの遷移を行っていた部分をmattabでで書き直しました。その際、ダミーで入れていたカードの部分をfirestoreから取得したデータに差し替えました（デザインの調整は後ほど行う予定です）

ご確認のほど宜しくお願い致します。

![image](https://user-images.githubusercontent.com/49504292/104094507-a03f9d00-52d4-11eb-8aa6-d5ebad98f0fc.png)
