### PR TITLE
Feature/68　退会時のデータ削除

### DIFF
--- a/functions/src/problem.function.ts
+++ b/functions/src/problem.function.ts
@@ -1,5 +1,6 @@
 import * as functions from 'firebase-functions';
 import { db } from './index';
+const firebaseTools = require('firebase-tools');
 
 const projectId = 'blanky-2fc41';
 
@@ -44,4 +45,18 @@ export const translateText = functions
           });
       });
     }
+  });
+
+export const deleteUserProblems = functions
+  .region('asia-northeast1')
+  .auth.user()
+  .onDelete(async (user) => {
+    const path = `problems/${user.uid}`;
+    const token = await functions.config().fb.token;
+    return firebaseTools.firestore.delete(path, {
+      project: process.env.GCLOUD_PROJECT,
+      recursive: true,
+      yes: true,
+      token,
+    });
   });

--- a/functions/src/sendmail.function.ts
+++ b/functions/src/sendmail.function.ts
@@ -18,3 +18,21 @@ export const welcomeEmail = functions
       return null;
     }
   });
+
+export const farewellEmail = functions
+  .region('asia-northeast1')
+  .auth.user()
+  .onDelete((user) => {
+    if (user.email) {
+      return sendEmail({
+        to: user.email,
+        templateId: 'd-f277afeff42a460187957615df4b89ec',
+        dynamicTemplateData: {
+          subject: 'blankyを退会しました',
+          name: user.displayName,
+        },
+      });
+    } else {
+      return null;
+    }
+  });


### PR DESCRIPTION
fix #68 

- ユーザーデータ削除
- ユーザーのプロフィール画像削除
- 対象ユーザーのstripeデータをfirestore内から削除（stripe上のデータはextentionsの関数で削除されます）
- ユーザーの作成した問題削除
- 退会時にメール送信

を行いました。ご確認のほど宜しくお願い致します。