### PR TITLE
 ログインから時間が立ってる時再ログインpopup表示

### DIFF
--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -42,6 +42,16 @@ export class AuthService {
   withdrawal() {
     this.db.doc(`problems/${this.uid}`).delete();
     const user = firebase.auth().currentUser;
-    user.delete().then(() => this.router.navigateByUrl('/'));
+    user
+      .delete()
+      .then(() => this.router.navigateByUrl('/'))
+      .catch((error) => {
+        if (error.code === 'auth/requires-recent-login') {
+          const provider = new firebase.auth.GoogleAuthProvider();
+          user.reauthenticateWithPopup(provider).then((result) => {
+            return null;
+          });
+        }
+      });
   }
 }


### PR DESCRIPTION
 fix #92 

退会時にログインから5分以上経っているとauth/requires-recent-loginのエラーが出てしまうため、再ログインするPopupを表示するよう修正しました。

ご確認のほど宜しくお願い致します。